### PR TITLE
Fix premature closing of the subscriber

### DIFF
--- a/pytroll_runner/__init__.py
+++ b/pytroll_runner/__init__.py
@@ -85,7 +85,7 @@ def read_config(config_file):
 def run_from_new_subscriber(command, subscriber_settings):
     """Run the command with files gotten from a new subscriber."""
     with closing(create_subscriber_from_dict_config(subscriber_settings)) as sub:
-        return run_on_messages(command, sub.recv())
+        yield from run_on_messages(command, sub.recv())
 
 
 def run_on_messages(command, messages):


### PR DESCRIPTION
This PR fixes a premature closing of the subscriber leading to the runner being deaf.

There is no test added here as I am counting on https://github.com/pytroll/posttroll/pull/57 to reveal the problem (it does locally)